### PR TITLE
Don't load all the apps when setting the signals for the models

### DIFF
--- a/validate_on_save/__init__.py
+++ b/validate_on_save/__init__.py
@@ -4,14 +4,17 @@
 
 from distutils.version import StrictVersion
 import django
-from django.db.models.loading import get_app, get_models
-
+from django.db.models.loading import load_app, cache, get_models, get_app
 
 __version__ = '1.1.0'
 
 
-def django_allows_app_config():
+def django_gte_17():
     return StrictVersion(django.get_version()) >= StrictVersion('1.7')
+
+
+def django_allows_app_config():
+    return django_gte_17()
 
 
 if django_allows_app_config():
@@ -25,8 +28,39 @@ def validate_models_on_save(app_name):
     compatibility reasons:
     http://stackoverflow.com/questions/4441539/why-doesnt-djangos-model-save-call-full-clean).
     """
+
+    if django_gte_17():
+        _validate_models_on_save_post_17(app_name)
+    else:
+        _validate_models_on_save_pre_17(app_name)
+
+
+def _validate_models_on_save_post_17(app_name):
     app = get_app(app_name)
     for model in get_models(app):
+        validate_model_on_save(model)
+
+
+def _validate_models_on_save_pre_17(app_name):
+
+    """
+    On Django < 1.7 we don't want all the apps to be loaded when the method is
+    being called for a specific app. It causes circular dependencies when apps
+    are trying to load stuff themselves through the template app loaders.
+
+    This is evident when running South management commands. For some reason they
+    load the template loaders which import all the apps which could import
+    something like haystack which imports all the indexes which could be part of
+    the models class of an app which uses validate on save in the models which
+    will load all the apps in order to get the models which loads debug toolbar
+    which calls a reverse on a url which loads all the context which may load
+    the template loaders again in the case of djangocms causing a circular
+    dependency.
+    """
+
+    load_app(app_name)
+    loaded_models = cache.app_models[app_name]
+    for (key, model) in loaded_models.items():
         validate_model_on_save(model)
 
 


### PR DESCRIPTION
This may cause some extreme circular imports when things are just right